### PR TITLE
Add inplace logical operators

### DIFF
--- a/include/hdltypes/impl/logic.hpp
+++ b/include/hdltypes/impl/logic.hpp
@@ -113,6 +113,11 @@ namespace hdltypes {
         return table[int(a.value())][int(b.value())];
     }
 
+    constexpr Logic& operator&= (Logic& a, Logic b) noexcept
+    {
+        return (a = a & b);
+    }
+
     constexpr Logic operator| (Logic a, Logic b) noexcept
     {
         constexpr Logic table[9][9] = {
@@ -127,6 +132,11 @@ namespace hdltypes {
             {'U'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l, 'X'_l, 'X'_l, '1'_l, 'X'_l}}; // -
         //    U      X      0      1      Z      W      L      H      -
         return table[int(a.value())][int(b.value())];
+    }
+
+    constexpr Logic& operator|= (Logic& a, Logic b) noexcept
+    {
+        return (a = a | b);
     }
 
     constexpr Logic operator^ (Logic a, Logic b) noexcept
@@ -145,12 +155,22 @@ namespace hdltypes {
         return table[int(a.value())][int(b.value())];
     }
 
+    constexpr Logic& operator^= (Logic& a, Logic b) noexcept
+    {
+        return (a = a ^ b);
+    }
+
     constexpr Logic operator~ (Logic a) noexcept
     {
         constexpr Logic table[9] = {
             'U'_l, 'X'_l, '1'_l, '0'_l, 'X'_l, 'X'_l, '1'_l, '0'_l, 'X'_l};
         //   U      X      0      1      Z      W      L      H      -
         return table[int(a.value())];
+    }
+
+    constexpr Logic& inplace_invert (Logic& a) noexcept
+    {
+        return (a = ~a);
     }
 
     constexpr bool is01(Logic a) noexcept
@@ -278,9 +298,19 @@ namespace hdltypes {
         return to_bit((a == '1'_b) && (b == '1'_b));
     }
 
+    constexpr Bit& operator&= (Bit& a, Bit b) noexcept
+    {
+        return (a = a & b);
+    }
+
     constexpr Bit operator| (Bit a, Bit b) noexcept
     {
         return to_bit((a == '1'_b) || (b == '1'_b));
+    }
+
+    constexpr Bit& operator|= (Bit& a, Bit b) noexcept
+    {
+        return (a = a | b);
     }
 
     constexpr Bit operator^ (Bit a, Bit b) noexcept
@@ -288,9 +318,19 @@ namespace hdltypes {
         return to_bit(a != b);
     }
 
+    constexpr Bit& operator^= (Bit& a, Bit b) noexcept
+    {
+        return (a = a ^ b);
+    }
+
     constexpr Bit operator~ (Bit a) noexcept
     {
         return to_bit(a == '0'_b);
+    }
+
+    constexpr Bit& inplace_invert (Bit& a) noexcept
+    {
+        return (a = ~a);
     }
 
     constexpr bool is01 (Bit a) noexcept

--- a/include/hdltypes/logic.hpp
+++ b/include/hdltypes/logic.hpp
@@ -119,14 +119,26 @@ namespace hdltypes {
     /** \relates Logic Logical "and" operation. See implementation for details. */
     constexpr Logic operator& (Logic a, Logic b) noexcept;
 
+    /** \relates Logic Inplace version of the logical "and" operation. */
+    constexpr Logic& operator&= (Logic& a, Logic b) noexcept;
+
     /** \relates Logic Logical "or" operation. See implementation for details. */
     constexpr Logic operator| (Logic a, Logic b) noexcept;
+
+    /** \relates Logic Inplace version of the logical "or" operation. */
+    constexpr Logic& operator|= (Logic& a, Logic b) noexcept;
 
     /** \relates Logic Logical "xor" operation. See implementation for details. */
     constexpr Logic operator^ (Logic a, Logic b) noexcept;
 
+    /** \relates Logic Inplace version of the logical "xor" operation. */
+    constexpr Logic& operator^= (Logic& a, Logic b) noexcept;
+
     /** \relates Logic Logical inversion operation. See implementation for details. */
     constexpr Logic operator~ (Logic a) noexcept;
+
+    /** \relates Logic Inplace version of the logical "invert" operation. */
+    constexpr Logic& inplace_invert (Logic& a) noexcept;
 
     /** \relates Logic Returns `true` if the value is `0` or `1`. */
     constexpr bool is01 (Logic a) noexcept;
@@ -231,14 +243,26 @@ namespace hdltypes {
     /** \relates Bit Logical "and" operation. Returns `1` if both arguments are `1`. */
     constexpr Bit operator& (Bit a, Bit b) noexcept;
 
+    /** \relates Bit Inplace version of the logical "and" operation. */
+    constexpr Bit& operator&= (Bit& a, Bit b) noexcept;
+
     /** \relates Bit Logical "or" operation. Returns `1` if either arguments are `1`. */
     constexpr Bit operator| (Bit a, Bit b) noexcept;
+
+    /** \relates Bit Inplace version of the logical "or" operation. */
+    constexpr Bit& operator|= (Bit& a, Bit b) noexcept;
 
     /** \relates Bit Logical "xor" operation. Returns `1` if arguments aren't equivalent. */
     constexpr Bit operator^ (Bit a, Bit b) noexcept;
 
+    /** \relates Bit Inplace version of the logical "xor" operation. */
+    constexpr Bit& operator^= (Bit& a, Bit b) noexcept;
+
     /** \relates Bit Logical inversion operation. Returns `1` if given `0`, and vice versa. */
     constexpr Bit operator~ (Bit a) noexcept;
+
+    /** \relates Bit Inplace version of the logical "invert" operation. */
+    constexpr Bit& inplace_invert (Bit& a) noexcept;
 
     /** \relates Bit Returns `true`. */
     constexpr bool is01 (Bit a) noexcept;

--- a/test/logic.cpp
+++ b/test/logic.cpp
@@ -1,5 +1,5 @@
 #include "catch2/catch.hpp"
-#include <hdltypes/logic.hpp>
+#include <hdltypes.hpp>
 
 using namespace hdltypes;
 
@@ -65,6 +65,26 @@ TEST_CASE("Logic operations", "[logic]")
     REQUIRE( ('X'_l ^ 'L'_l) == 'X'_l );
     REQUIRE( ('W'_l & 'U'_l) == 'U'_l );
     REQUIRE( ~'L'_l == '1'_l );
+
+    {   auto a = 'H'_l;
+        a &= '1'_l;
+        REQUIRE(a == '1'_l);
+    }
+
+    {   auto a = '0'_l;
+        a |= '1'_l;
+        REQUIRE(a == '1'_l);
+    }
+
+    {   auto a = 'W'_l;
+        a ^= '1'_l;
+        REQUIRE(a == 'X'_l);
+    }
+
+    {   auto a = '0'_l;
+        inplace_invert(a);
+        REQUIRE(a == '1'_l);
+    }
 }
 
 TEST_CASE("Bit serialization", "[logic]")
@@ -118,4 +138,24 @@ TEST_CASE("Bit operations", "[logic]")
 
     REQUIRE( ~'0'_b == '1'_b );
     REQUIRE( ~'1'_b == '0'_b );
+
+    {   auto a = '0'_b;
+        a &= '1'_b;
+        REQUIRE(a == '0'_b);
+    }
+
+    {   auto a = '0'_b;
+        a |= '1'_b;
+        REQUIRE(a == '1'_b);
+    }
+
+    {   auto a = '1'_b;
+        a ^= '1'_b;
+        REQUIRE(a == '0'_b);
+    }
+
+    {   auto a = '0'_b;
+        inplace_invert(a);
+        REQUIRE(a == '1'_b);
+    }
 }


### PR DESCRIPTION
Closes #8. Add inplace logical operators for `&`, `|`, `^`, and `~`.