### PR TITLE
Move from serialize/deserialize to to_(logic|bit)/to_char

### DIFF
--- a/include/hdltypes/impl/logic.hpp
+++ b/include/hdltypes/impl/logic.hpp
@@ -212,13 +212,15 @@ namespace hdltypes {
         assert(bit_value_valid(value_));
     }
 
-    template <typename CharType>
-    constexpr Bit Bit::deserialize(const CharType& c)
+    template <typename CharType, typename std::enable_if<
+        util::is_char_type<CharType>::value
+    , int>::type>
+    constexpr Bit to_bit(const CharType& c)
     {
         switch (c)
         {
-            case '0': return Bit(_0);
-            case '1': return Bit(_1);
+            case '0': return Bit(Bit::_0);
+            case '1': return Bit(Bit::_1);
         }
         throw std::invalid_argument("Given value is not a Bit");
     }
@@ -230,14 +232,14 @@ namespace hdltypes {
     }
 
     template <typename CharType>
-    constexpr CharType Bit::serialize() const noexcept
+    constexpr CharType to_char(const Bit a) noexcept
     {
-        return (value() == _1) ? '1' : '0';
+        return (a.value() == Bit::_1) ? '1' : '0';
     }
 
     constexpr Bit operator ""_b (char c)
     {
-        return Bit::deserialize(c);
+        return to_bit(c);
     }
 
     constexpr Bit to_bit(Logic a)
@@ -275,6 +277,7 @@ namespace hdltypes {
 
     template <typename IntType, typename std::enable_if<
         std::is_integral<IntType>::value &&
+        !util::is_char_type<IntType>::value &&
         !std::is_same<IntType, bool>::value
     , int>::type>
     constexpr Bit to_bit(const IntType& i)

--- a/include/hdltypes/impl/logic.hpp
+++ b/include/hdltypes/impl/logic.hpp
@@ -1,12 +1,13 @@
 #ifndef HDLTYPES_IMPL_LOGIC_HPP
 #define HDLTYPES_IMPL_LOGIC_HPP
+#include "hdltypes/logic.hpp"
 
 #include <cstdint>          // uint8_t
 #include <type_traits>      // enable_if_t, is_same_v, is_integral
 #include <stdexcept>        // invalid_argument
 #include <cassert>
 
-#include "hdltypes/logic.hpp"
+#include "hdltypes/utils.hpp"   // is_char_type
 
 
 namespace hdltypes {
@@ -25,26 +26,28 @@ namespace hdltypes {
         assert(logic_value_valid(value_));
     }
 
-    template <typename CharType>
-    constexpr Logic Logic::deserialize(const CharType& c)
+    template <typename CharType, typename std::enable_if<
+        util::is_char_type<CharType>::value
+    , int>::type>
+    constexpr Logic to_logic(const CharType& c)
     {
         switch (c)
         {
-            case 'U': return Logic(U);
-            case 'u': return Logic(U);
-            case 'X': return Logic(X);
-            case 'x': return Logic(X);
-            case '0': return Logic(_0);
-            case '1': return Logic(_1);
-            case 'Z': return Logic(Z);
-            case 'z': return Logic(Z);
-            case 'W': return Logic(W);
-            case 'w': return Logic(W);
-            case 'L': return Logic(L);
-            case 'l': return Logic(L);
-            case 'H': return Logic(H);
-            case 'h': return Logic(H);
-            case '-': return Logic(DC);
+            case 'U': return Logic(Logic::U);
+            case 'u': return Logic(Logic::U);
+            case 'X': return Logic(Logic::X);
+            case 'x': return Logic(Logic::X);
+            case '0': return Logic(Logic::_0);
+            case '1': return Logic(Logic::_1);
+            case 'Z': return Logic(Logic::Z);
+            case 'z': return Logic(Logic::Z);
+            case 'W': return Logic(Logic::W);
+            case 'w': return Logic(Logic::W);
+            case 'L': return Logic(Logic::L);
+            case 'l': return Logic(Logic::L);
+            case 'H': return Logic(Logic::H);
+            case 'h': return Logic(Logic::H);
+            case '-': return Logic(Logic::DC);
         }
         throw std::invalid_argument("Given value is not a Logic");
     }
@@ -56,20 +59,21 @@ namespace hdltypes {
     }
 
     template <typename CharType>
-    constexpr CharType Logic::serialize() const noexcept
+    constexpr CharType to_char(const Logic a) noexcept
     {
         constexpr CharType table[9] = {
             'U', 'X', '0', '1', 'Z', 'W', 'L', 'H', '-'};
-        return table[int(value())];
+        return table[int(a.value())];
     }
 
     constexpr Logic operator ""_l (char c)
     {
-        return Logic::deserialize(c);
+        return to_logic(c);
     }
 
     template <typename IntType, typename std::enable_if<
         std::is_integral<IntType>::value &&
+        !util::is_char_type<IntType>::value &&
         !std::is_same<IntType, bool>::value
     , int>::type>
     constexpr Logic to_logic(const IntType& i)

--- a/include/hdltypes/logic.hpp
+++ b/include/hdltypes/logic.hpp
@@ -199,24 +199,10 @@ namespace hdltypes {
             */
         explicit constexpr Bit(value_type value) noexcept;
 
-        /** Converts character values into Logic. See table below for more details.
-
-        \verbatim
-            '0'      => _0
-            '1'      => _1
-        \endverbatim
-            */
-        template <typename CharType>
-        static constexpr Bit deserialize(const CharType& c);
-
     public:  // attributes
 
         /** Obtain the value_type value. */
         constexpr value_type value() const noexcept;
-
-        /** Convert a Bit into a printable representation. */
-        template <typename CharType = char>
-        constexpr CharType serialize() const noexcept;
 
     public:  // Logic conversion
 
@@ -240,9 +226,22 @@ namespace hdltypes {
     /** \relates Bit Converts integer values `0` and `1` into Bit `0` and `1`, respectively. */
     template <typename IntType, typename std::enable_if<
         std::is_integral<IntType>::value &&
+        !util::is_char_type<IntType>::value &&
         !std::is_same<IntType, bool>::value
     , int>::type = 0>
     constexpr Bit to_bit(const IntType& i);
+
+    /** Converts character values into Logic. See table below for more details.
+
+    \verbatim
+        '0'      => _0
+        '1'      => _1
+    \endverbatim
+        */
+    template <typename CharType, typename std::enable_if<
+        util::is_char_type<CharType>::value
+    , int>::type = 0>
+    static constexpr Bit to_bit(const CharType& c);
 
     /** \relates Bit Converts the Logic values `0` and `1` to Bit `0` and `1`, respectively. */
     constexpr Bit to_bit(Logic a);
@@ -289,6 +288,10 @@ namespace hdltypes {
 
     /** \relates Bit Converts a Bit `0` or `1` to the boolean `false` or `true`, respectively. */
     constexpr bool to_bool(Bit a) noexcept;
+
+    /** \relates Bit Converts a Bit `0` or `1` to the characters `'0'` and `'1'`, respectively. */
+    template <typename CharType = char>
+    constexpr CharType to_char(const Bit a) noexcept;
 
 }
 

--- a/include/hdltypes/logic.hpp
+++ b/include/hdltypes/logic.hpp
@@ -1,8 +1,9 @@
 #ifndef HDLTYPES_LOGIC_HPP
 #define HDLTYPES_LOGIC_HPP
 
-#include <cstdint>          // uint8_t
-#include <type_traits>      // enable_if, is_same, is_integral
+#include <cstdint>              // uint8_t
+#include <type_traits>          // enable_if, is_same, is_integral
+#include "hdltypes/utils.hpp"   // util::is_char_type
 
 
 namespace hdltypes {
@@ -66,31 +67,10 @@ namespace hdltypes {
             */
         explicit constexpr Logic(value_type value) noexcept;
 
-        /** Converts character values into Logic. See table below for more details.
-
-        \verbatim
-            'U'  'u'    => U
-            'X'  'x'    => X
-            '0'         => _0
-            '1'         => _1
-            'Z'  'z'    => Z
-            'W'  'w'    => W
-            'L'  'l'    => L
-            'H'  'h'    => H
-            '-'         => DC
-        \endverbatim
-            */
-        template <typename CharType>
-        static constexpr Logic deserialize(const CharType& c);
-
     public:  // attributes
 
         /** Obtain the value_type value. */
         constexpr value_type value() const noexcept;
-
-        /** Convert a Logic into a printable representation. */
-        template <typename CharType = char>
-        constexpr CharType serialize() const noexcept;
 
     private: // members
 
@@ -106,9 +86,29 @@ namespace hdltypes {
     /** \relates Logic Converts integer values `0` and `1` into Logic `0` and `1`, respectively. */
     template <typename IntType, typename std::enable_if<
         std::is_integral<IntType>::value &&
+        !util::is_char_type<IntType>::value &&
         !std::is_same<IntType, bool>::value
     , int>::type = 0>
     constexpr Logic to_logic(const IntType& i);
+
+    /** Converts character values into Logic. See table below for more details.
+
+    \verbatim
+        'U'  'u'    => U
+        'X'  'x'    => X
+        '0'         => _0
+        '1'         => _1
+        'Z'  'z'    => Z
+        'W'  'w'    => W
+        'L'  'l'    => L
+        'H'  'h'    => H
+        '-'         => DC
+    \endverbatim
+        */
+    template <typename CharType, typename std::enable_if<
+        util::is_char_type<CharType>::value
+    , int>::type = 0>
+    constexpr Logic to_logic(const CharType& c);
 
     /** \relates Logic Value equality. */
     constexpr bool operator== (Logic a, Logic b) noexcept;
@@ -150,6 +150,22 @@ namespace hdltypes {
     /** \relates Logic Converts a Logic `0`/`L` or `1`/`H` to the integer `false` or `true`, respectively. */
     constexpr bool to_bool(Logic a);
 
+    /** \relates Logic Converts a Logic into a character. See the below details for the mapping.
+
+    \verbatim
+        U       => 'U'
+        X       => 'X'
+        _0      => '0'
+        _1      => '1'
+        Z       => 'Z'
+        W       => 'W'
+        L       => 'L'
+        H       => 'H'
+        DC      => '-'
+    \endverbatim
+        */
+    template <typename CharType = char>
+    constexpr CharType to_char(Logic a) noexcept;
 
     /** Bit value type
 

--- a/include/hdltypes/utils.hpp
+++ b/include/hdltypes/utils.hpp
@@ -1,0 +1,30 @@
+#ifndef HDLTYPES_UTIL_HPP
+#define HDLTYPES_UTIL_HPP
+
+namespace hdltypes { namespace util {
+
+
+/** User overloadable check to see if a type is a character type */
+template <typename T>
+struct is_char_type
+{
+    static constexpr bool value = false;
+};
+
+#define def_is_char_type(type) \
+template <> struct is_char_type<type> { static constexpr bool value = true; };
+
+def_is_char_type(char);
+def_is_char_type(wchar_t);
+def_is_char_type(char16_t);
+def_is_char_type(char32_t);
+#if cplusplus > 201703L
+def_is_char_type(char8_t);
+#endif
+
+#undef def_is_char_type
+
+
+}}
+
+#endif

--- a/test/logic.cpp
+++ b/test/logic.cpp
@@ -4,39 +4,43 @@
 using namespace hdltypes;
 
 
-TEST_CASE("Logic serialization", "[logic]")
+TEST_CASE("Logic char conversions", "[logic]")
 {
-    REQUIRE( Logic::deserialize('U').serialize() == 'U' );
-    REQUIRE( Logic::deserialize('u').serialize() == 'U' );
-    REQUIRE( Logic::deserialize('X').serialize() == 'X' );
-    REQUIRE( Logic::deserialize('x').serialize() == 'X' );
-    REQUIRE( Logic::deserialize('0').serialize() == '0' );
-    REQUIRE( Logic::deserialize('1').serialize() == '1' );
-    REQUIRE( Logic::deserialize('Z').serialize() == 'Z' );
-    REQUIRE( Logic::deserialize('z').serialize() == 'Z' );
-    REQUIRE( Logic::deserialize('W').serialize() == 'W' );
-    REQUIRE( Logic::deserialize('w').serialize() == 'W' );
-    REQUIRE( Logic::deserialize('L').serialize() == 'L' );
-    REQUIRE( Logic::deserialize('l').serialize() == 'L' );
-    REQUIRE( Logic::deserialize('H').serialize() == 'H' );
-    REQUIRE( Logic::deserialize('h').serialize() == 'H' );
-    REQUIRE( Logic::deserialize('-').serialize() == '-' );
+    REQUIRE( to_char(to_logic('U')) == 'U' );
+    REQUIRE( to_char(to_logic('u')) == 'U' );
+    REQUIRE( to_char(to_logic('X')) == 'X' );
+    REQUIRE( to_char(to_logic('x')) == 'X' );
+    REQUIRE( to_char(to_logic('0')) == '0' );
+    REQUIRE( to_char(to_logic('1')) == '1' );
+    REQUIRE( to_char(to_logic('Z')) == 'Z' );
+    REQUIRE( to_char(to_logic('z')) == 'Z' );
+    REQUIRE( to_char(to_logic('W')) == 'W' );
+    REQUIRE( to_char(to_logic('w')) == 'W' );
+    REQUIRE( to_char(to_logic('L')) == 'L' );
+    REQUIRE( to_char(to_logic('l')) == 'L' );
+    REQUIRE( to_char(to_logic('H')) == 'H' );
+    REQUIRE( to_char(to_logic('h')) == 'H' );
+    REQUIRE( to_char(to_logic('-')) == '-' );
 
-    REQUIRE_THROWS( Logic::deserialize('8') );
-    REQUIRE_THROWS( Logic::deserialize('\0') );
+    REQUIRE_THROWS( to_logic('8') );
+    REQUIRE_THROWS( to_logic('\0') );
 }
 
-TEST_CASE("Logic conversions", "[logic]")
+TEST_CASE("Logic int conversions", "[logic]")
 {
     REQUIRE( to_int(to_logic(0)) == 0 );
     REQUIRE( to_int(to_logic(1)) == 1 );
 
+    REQUIRE_THROWS( to_int('U'_l) );
+    REQUIRE_THROWS( to_logic(2) );
+}
+
+TEST_CASE("Logic bool conversions", "[logic]")
+{
     REQUIRE( to_bool(to_logic(false)) == false );
     REQUIRE( to_bool(to_logic(true)) == true );
 
-    REQUIRE_THROWS( to_int('U'_l) );
     REQUIRE_THROWS( to_bool('U'_l) );
-    REQUIRE_THROWS( to_logic(2) );
 }
 
 TEST_CASE("Logic attributes", "[logic]")
@@ -87,21 +91,25 @@ TEST_CASE("Logic operations", "[logic]")
     }
 }
 
-TEST_CASE("Bit serialization", "[logic]")
+TEST_CASE("Bit char conversions", "[logic]")
 {
-    REQUIRE( Bit::deserialize('0').serialize() == '0' );
-    REQUIRE( Bit::deserialize('1').serialize() == '1' );
+    REQUIRE( to_char(to_bit('0')) == '0' );
+    REQUIRE( to_char(to_bit('1')) == '1' );
 
-    REQUIRE_THROWS( Bit::deserialize('\0') );
-    REQUIRE_THROWS( Bit::deserialize('X') );
+    REQUIRE_THROWS( to_bit('\0') );
+    REQUIRE_THROWS( to_bit('X') );
 }
 
-TEST_CASE("Bit conversions", "[logic]")
+TEST_CASE("Bit int conversions", "[logic]")
 {
     REQUIRE( to_bit(0) == '0'_b );
     REQUIRE( to_bit(1) == '1'_b );
-    REQUIRE_THROWS( to_bit(123) );
 
+    REQUIRE_THROWS( to_bit(123) );
+}
+
+TEST_CASE("Bit bool conversions", "[logic]")
+{
     REQUIRE( to_bit(false) == '0'_b );
     REQUIRE( to_bit(true) == '1'_b );
 }


### PR DESCRIPTION
Previously this was an issue because there was no utility to segregate integer types from character types, which cause ambiguity errors. We introduce the `is_char_type` type checker which returns `true` if the type is a character type. The user is expected to do template overloads if they have a custom character type that isn't one of the following:

* `char`
* `wchar_t`
* `char16_t`
* `char32_t`
* `char8_t`

With this change, we changed the separate serialize/serialize routines that deal with conversion to/from characters types on both the `Logic` and `Bit` to be `to_logic`, `to_bit`, and `to_char` overloads. This makes the type system more consistent, and will ease logic vector implementations.