### PR TITLE
Improve is_integer_type and is_char_type support

### DIFF
--- a/include/hdltypes/impl/logic.hpp
+++ b/include/hdltypes/impl/logic.hpp
@@ -12,6 +12,8 @@
 
 namespace hdltypes {
 
+using namespace util;
+
 namespace {
 
     static constexpr bool logic_value_valid(const Logic::value_type value)
@@ -27,7 +29,7 @@ constexpr Logic::Logic(const value_type value) noexcept : value_(value)
 }
 
 template <typename CharType, typename std::enable_if<
-    util::is_char_type<CharType>::value
+    is_char_type<CharType>::value
 , int>::type>
 constexpr Logic to_logic(const CharType& c)
 {
@@ -72,7 +74,7 @@ constexpr Logic operator ""_l (const char c)
 }
 
 template <typename IntType, typename std::enable_if<
-    util::is_integer_type<IntType>::value
+    is_integer_type<IntType>::value
 , int>::type>
 constexpr Logic to_logic(const IntType& i)
 {
@@ -217,7 +219,7 @@ constexpr Bit::Bit(const value_type value) noexcept : value_(value)
 }
 
 template <typename CharType, typename std::enable_if<
-    util::is_char_type<CharType>::value
+    is_char_type<CharType>::value
 , int>::type>
 constexpr Bit to_bit(const CharType& c)
 {
@@ -281,7 +283,7 @@ constexpr Bit to_bit(const bool b) noexcept
 }
 
 template <typename IntType, typename std::enable_if<
-    util::is_integer_type<IntType>::value
+    is_integer_type<IntType>::value
 , int>::type>
 constexpr Bit to_bit(const IntType& i)
 {

--- a/include/hdltypes/logic.hpp
+++ b/include/hdltypes/logic.hpp
@@ -8,6 +8,8 @@
 
 namespace hdltypes {
 
+using namespace util;
+
 /** Logic value type
 
     This effectively models VHDL's std_ulogic type. See value_type for details on the
@@ -73,7 +75,7 @@ constexpr Logic to_logic(bool b) noexcept;
 
 /** \relates Logic Converts integer values `0` and `1` into Logic `0` and `1`, respectively. */
 template <typename IntType, typename std::enable_if<
-    util::is_integer_type<IntType>::value
+    is_integer_type<IntType>::value
 , int>::type = 0>
 constexpr Logic to_logic(const IntType& i);
 
@@ -92,7 +94,7 @@ constexpr Logic to_logic(const IntType& i);
 \endverbatim
     */
 template <typename CharType, typename std::enable_if<
-    util::is_char_type<CharType>::value
+    is_char_type<CharType>::value
 , int>::type = 0>
 constexpr Logic to_logic(const CharType& c);
 
@@ -214,7 +216,7 @@ constexpr Bit to_bit(bool b) noexcept;
 
 /** \relates Bit Converts integer values `0` and `1` into Bit `0` and `1`, respectively. */
 template <typename IntType, typename std::enable_if<
-    util::is_integer_type<IntType>::value
+    is_integer_type<IntType>::value
 , int>::type = 0>
 constexpr Bit to_bit(const IntType& i);
 
@@ -226,7 +228,7 @@ constexpr Bit to_bit(const IntType& i);
 \endverbatim
     */
 template <typename CharType, typename std::enable_if<
-    util::is_char_type<CharType>::value
+    is_char_type<CharType>::value
 , int>::type = 0>
 constexpr Bit to_bit(const CharType& c);
 

--- a/include/hdltypes/utils.hpp
+++ b/include/hdltypes/utils.hpp
@@ -1,22 +1,25 @@
 #ifndef HDLTYPES_UTIL_HPP
 #define HDLTYPES_UTIL_HPP
 
-#include <type_traits>  // false_type, true_type
+#include <type_traits>  // false_type, true_type, remove_cv
 
 namespace hdltypes { namespace util {
 
 
 /** User overloadable check to see if a type is a character type */
 template <typename T>
-struct is_char_type : std::false_type {};
+struct _is_char_type : std::false_type {};
 
-template <> struct is_char_type<char> : std::true_type {};
-template <> struct is_char_type<wchar_t> : std::true_type {};
-template <> struct is_char_type<char16_t> : std::true_type {};
-template <> struct is_char_type<char32_t> : std::true_type {};
+template <> struct _is_char_type<char> : std::true_type {};
+template <> struct _is_char_type<wchar_t> : std::true_type {};
+template <> struct _is_char_type<char16_t> : std::true_type {};
+template <> struct _is_char_type<char32_t> : std::true_type {};
 #if cplusplus >= 202000L
-template <> struct is_char_type<char8_t> : std::true_type {};
+template <> struct _is_char_type<char8_t> : std::true_type {};
 #endif
+
+template <typename T>
+struct is_char_type : _is_char_type<typename std::remove_cv<T>::type> {};
 
 
 /*
@@ -26,18 +29,21 @@ template <> struct is_char_type<char8_t> : std::true_type {};
 
 /** User overloadable check to see if a type is an integer type */
 template <typename T>
-struct is_integer_type : std::false_type {};
+struct _is_integer_type : std::false_type {};
 
-template <> struct is_integer_type<unsigned char> : std::true_type {};
-template <> struct is_integer_type<signed char> : std::true_type {};
-template <> struct is_integer_type<unsigned short> : std::true_type {};
-template <> struct is_integer_type<signed short> : std::true_type {};
-template <> struct is_integer_type<unsigned int> : std::true_type {};
-template <> struct is_integer_type<signed int> : std::true_type {};
-template <> struct is_integer_type<unsigned long> : std::true_type {};
-template <> struct is_integer_type<signed long> : std::true_type {};
-template <> struct is_integer_type<unsigned long long> : std::true_type {};
-template <> struct is_integer_type<signed long long> : std::true_type {};
+template <> struct _is_integer_type<unsigned char> : std::true_type {};
+template <> struct _is_integer_type<signed char> : std::true_type {};
+template <> struct _is_integer_type<unsigned short> : std::true_type {};
+template <> struct _is_integer_type<signed short> : std::true_type {};
+template <> struct _is_integer_type<unsigned int> : std::true_type {};
+template <> struct _is_integer_type<signed int> : std::true_type {};
+template <> struct _is_integer_type<unsigned long> : std::true_type {};
+template <> struct _is_integer_type<signed long> : std::true_type {};
+template <> struct _is_integer_type<unsigned long long> : std::true_type {};
+template <> struct _is_integer_type<signed long long> : std::true_type {};
+
+template <typename T>
+struct is_integer_type : _is_integer_type<typename std::remove_cv<T>::type> {};
 
 
 }}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(catch2content)
 
-add_executable(test_hdltypes EXCLUDE_FROM_ALL main.cpp logic.cpp)
+add_executable(test_hdltypes EXCLUDE_FROM_ALL main.cpp logic.cpp utils.cpp)
 
 target_link_libraries(test_hdltypes PRIVATE ${PROJECT_NAME} Catch2::Catch2)
 

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,0 +1,40 @@
+#include "hdltypes.hpp"
+#include <cstdint>
+
+using hdltypes::util::is_integer_type;
+using hdltypes::util::is_char_type;
+
+
+static_assert(is_integer_type<unsigned char>::value);
+static_assert(is_integer_type<signed char>::value);
+static_assert(is_integer_type<unsigned short>::value);
+static_assert(is_integer_type<signed short>::value);
+static_assert(is_integer_type<unsigned int>::value);
+static_assert(is_integer_type<signed int>::value);
+static_assert(is_integer_type<unsigned long>::value);
+static_assert(is_integer_type<signed long>::value);
+static_assert(is_integer_type<unsigned long long>::value);
+static_assert(is_integer_type<signed long long>::value);
+static_assert(is_integer_type<std::size_t>::value);
+static_assert(is_integer_type<uint8_t>::value);
+static_assert(is_integer_type<int8_t>::value);
+static_assert(is_integer_type<uint16_t>::value);
+static_assert(is_integer_type<int16_t>::value);
+static_assert(is_integer_type<uint32_t>::value);
+static_assert(is_integer_type<int32_t>::value);
+static_assert(is_integer_type<uint64_t>::value);
+static_assert(is_integer_type<int64_t>::value);
+static_assert(is_integer_type<uintptr_t>::value);
+static_assert(is_integer_type<intptr_t>::value);
+static_assert(is_integer_type<intmax_t>::value);
+static_assert(is_integer_type<uintmax_t>::value);
+static_assert(is_integer_type<const volatile int>::value);
+
+static_assert(!is_integer_type<bool>::value);
+static_assert(!is_integer_type<char>::value);
+
+static_assert(is_char_type<char>::value);
+static_assert(is_char_type<wchar_t>::value);
+static_assert(is_char_type<char16_t>::value);
+static_assert(is_char_type<char32_t>::value);
+static_assert(is_char_type<const volatile char>::value);


### PR DESCRIPTION
Closes #19. Now accept CV-qualified types, added tests, moved to using unqualified name in their usage to allow user overloads via ADL.